### PR TITLE
make clippy pedantic and appease most of its complaints

### DIFF
--- a/tree-buf/src/experimental/stats.rs
+++ b/tree-buf/src/experimental/stats.rs
@@ -111,7 +111,7 @@ fn visit_array(path: &Path, branch: &DynArrayBranch, breakdown: &mut SizeBreakdo
         }
         DynArrayBranch::Boolean(enc) => match enc {
             ArrayBool::Packed(b) => breakdown.add(&path, "Packed Boolean", b),
-            ArrayBool::RLE(_first, runs) => visit_array(&path.a(&"runs", &"Bool RLE"), runs, breakdown),
+            ArrayBool::Rle(_first, runs) => visit_array(&path.a(&"runs", &"Bool Rle"), runs, breakdown),
         },
         DynArrayBranch::Float(f) => match f {
             ArrayFloat::DoubleGorilla(b) => breakdown.add(&path, "Gorilla", b),
@@ -136,9 +136,9 @@ fn visit_array(path: &Path, branch: &DynArrayBranch, breakdown: &mut SizeBreakdo
                 visit_array(&path.a(name, &"Object"), field, breakdown);
             }
         }
-        DynArrayBranch::RLE { runs, values } => {
-            visit_array(&path.a(&"runs", &"RLE"), runs, breakdown);
-            visit_array(&path.a(&"values", &"RLE"), values, breakdown);
+        DynArrayBranch::Rle { runs, values } => {
+            visit_array(&path.a(&"runs", &"Rle"), runs, breakdown);
+            visit_array(&path.a(&"values", &"Rle"), values, breakdown);
         }
         DynArrayBranch::Dictionary { indices, values } => {
             visit_array(&path.a(&"indices", &"Dictionary"), indices, breakdown);
@@ -239,16 +239,16 @@ fn visit(path: &Path, branch: &DynRootBranch<'_>, breakdown: &mut SizeBreakdown)
 ///            Object.Object.Array.Object.Object.Object.Array.Enum.Packed Boolean
 ///         120
 ///            data.orders.[1000].nft.wearable.bodyShapes.len.runs
-///            Object.Object.Array.Object.Object.Object.Array.RLE.Simple16
+///            Object.Object.Array.Object.Object.Object.Array.Rle.Simple16
 ///         85
 ///            data.orders.[1000].nft.wearable.collection.values
 ///            Object.Object.Array.Object.Object.Object.Dictionary.UTF-8
 ///         60
 ///            data.orders.[1000].nft.wearable.bodyShapes.len.values
-///            Object.Object.Array.Object.Object.Object.Array.RLE.Simple16
+///            Object.Object.Array.Object.Object.Object.Array.Rle.Simple16
 ///         2
 ///            data.orders.[1000].nft.wearable.owner.mana.runs
-///            Object.Object.Array.Object.Object.Object.Object.Bool RLE.Prefix Varint
+///            Object.Object.Array.Object.Object.Object.Object.Bool Rle.Prefix Varint
 ///
 /// Largest by type:
 ///          1x 32000 @ U8 Fixed

--- a/tree-buf/src/internal/branch/root_branch.rs
+++ b/tree-buf/src/internal/branch/root_branch.rs
@@ -52,8 +52,6 @@ pub enum DynRootBranch<'a> {
 }
 
 pub fn decode_next_root<'a>(bytes: &'a [u8], offset: &'_ mut usize, lens: &'_ mut usize) -> DecodeResult<DynRootBranch<'a>> {
-    let id = RootTypeId::decode_next(bytes, offset)?;
-
     // See also e25db64d-8424-46b9-bdc1-cdb618807513
     fn decode_tuple<'a>(num_fields: usize, bytes: &'a [u8], offset: &'_ mut usize, lens: &'_ mut usize) -> DecodeResult<DynRootBranch<'a>> {
         let mut fields = Vec::with_capacity(num_fields);
@@ -91,6 +89,9 @@ pub fn decode_next_root<'a>(bytes: &'a [u8], offset: &'_ mut usize, lens: &'_ mu
         NaN, NegOne, Obj0, Obj1, Obj2, Obj3, Obj4, Obj5, Obj6, Obj7, Obj8, ObjN, One, Str, Str0, Str1, Str2, Str3, True, Tuple2, Tuple3, Tuple4, Tuple5, Tuple6, Tuple7, Tuple8,
         TupleN, Void, Zero, F32, F64,
     };
+
+    let id = RootTypeId::decode_next(bytes, offset)?;
+
     let branch = match id {
         Void => DynRootBranch::Void,
 

--- a/tree-buf/src/internal/buffer.rs
+++ b/tree-buf/src/internal/buffer.rs
@@ -67,6 +67,7 @@ impl<T> Buffer<T> {
     pub const CAPACITY: usize = SIZE / size_of::<T>();
 
     #[inline(always)]
+    #[allow(clippy::unused_self)]
     pub const fn capacity(&self) -> usize {
         Self::CAPACITY
     }

--- a/tree-buf/src/internal/encodings/gorilla_old.rs
+++ b/tree-buf/src/internal/encodings/gorilla_old.rs
@@ -16,11 +16,11 @@ where
     if last_byte_count * 8 != num_bits_last_elm {
         last_byte_count += 1;
     }
-    let last = &bytes[bytes.len() - last_byte_count as usize..];
-    let bytes = &bytes[..bytes.len() - last.len()];
+    let last_bytes = &bytes[bytes.len() - last_byte_count as usize..];
+    let bytes = &bytes[..bytes.len() - last_bytes.len()];
     let mut last_2 = [0_u8; 8];
-    for (i, value) in last.iter().enumerate() {
-        last_2[i + (8 - last.len())] = *value;
+    for (i, value) in last_bytes.iter().enumerate() {
+        last_2[i + (8 - last_bytes.len())] = *value;
     }
     let last = u64::from_le_bytes(last_2);
     // TODO: Change this to check that num_bits_last_elm is correct

--- a/tree-buf/src/internal/encodings/packed_bool.rs
+++ b/tree-buf/src/internal/encodings/packed_bool.rs
@@ -4,8 +4,11 @@ use crate::prelude::*;
 pub fn encode_packed_bool(items: &[bool], bytes: &mut Vec<u8>) {
     profile_fn!(encode_packed_bool);
 
+    bytes.reserve(items.len() / 8);
+
     let mut offset = 0;
     while offset + 7 < items.len() {
+        #[allow(clippy::identity_op)]
         let b = (items[offset + 0] as u8) << 0
             | (items[offset + 1] as u8) << 1
             | (items[offset + 2] as u8) << 2

--- a/tree-buf/src/internal/encodings/rle.rs
+++ b/tree-buf/src/internal/encodings/rle.rs
@@ -72,12 +72,12 @@ impl<T: Send + Clone> RleIterator<T> {
     }
 }
 
-pub(crate) struct RLE<S> {
+pub(crate) struct Rle<S> {
     // TODO: (Performance) Do not require the allocation of this Vec
     sub_compressors: S,
 }
 
-impl<S> RLE<S> {
+impl<S> Rle<S> {
     pub fn new(sub_compressors: S) -> Self {
         Self { sub_compressors }
     }
@@ -122,7 +122,7 @@ fn get_runs<T: PartialEq + Copy>(data: &[T]) -> Result<(Vec<u64>, Vec<T>), ()> {
     }
 }
 
-impl<T: PartialEq + Copy + std::fmt::Debug, S: CompressorSet<T>> Compressor<T> for RLE<S> {
+impl<T: PartialEq + Copy + std::fmt::Debug, S: CompressorSet<T>> Compressor<T> for Rle<S> {
     fn compress<O: EncodeOptions>(&self, data: &[T], stream: &mut EncoderStream<'_, O>) -> Result<ArrayTypeId, ()> {
         profile_method!(compress);
 
@@ -132,7 +132,7 @@ impl<T: PartialEq + Copy + std::fmt::Debug, S: CompressorSet<T>> Compressor<T> f
             stream.encode_with_id(|stream| compress(&values[..], stream, &self.sub_compressors));
             stream.encode_with_id(|stream| runs.flush(stream));
 
-            Ok(ArrayTypeId::RLE)
+            Ok(ArrayTypeId::Rle)
         })
     }
 

--- a/tree-buf/src/internal/encodings/rle_bool.rs
+++ b/tree-buf/src/internal/encodings/rle_bool.rs
@@ -32,7 +32,7 @@ fn bool_runs_and_id(items: &[bool]) -> Result<(Vec<u64>, ArrayTypeId), ()> {
     }
 
     let mut current_value = items[0];
-    let type_id = if current_value { ArrayTypeId::RLEBoolTrue } else { ArrayTypeId::RLEBoolFalse };
+    let type_id = if current_value { ArrayTypeId::RleBoolTrue } else { ArrayTypeId::RleBoolFalse };
     let mut current_run: u64 = 0;
     // TODO: (Performance) use second-stack
     let mut runs = Vec::new();

--- a/tree-buf/src/internal/types/boolean.rs
+++ b/tree-buf/src/internal/types/boolean.rs
@@ -41,7 +41,7 @@ impl EncoderArray<bool> for Vec<bool> {
         profile_method!(encode_all);
 
         // See also 42d5f4b4-823f-4ab4-8448-6e1a341ff28b
-        let compressors = (PackedBoolCompressor, RLEBoolCompressor);
+        let compressors = (PackedBoolCompressor, RleBoolCompressor);
         compress(values, stream, &compressors)
     }
     fn flush<O: EncodeOptions>(self, stream: &mut EncoderStream<'_, O>) -> ArrayTypeId {
@@ -52,7 +52,7 @@ impl EncoderArray<bool> for Vec<bool> {
 impl PrimitiveEncoderArray<bool> for Vec<bool> {
     fn fast_size_for_all<O: EncodeOptions>(values: &[bool], options: &O) -> usize {
         // See also 42d5f4b4-823f-4ab4-8448-6e1a341ff28b
-        let compressors = (PackedBoolCompressor, RLEBoolCompressor);
+        let compressors = (PackedBoolCompressor, RleBoolCompressor);
         fast_size_for(values, &compressors, options)
     }
 }
@@ -71,9 +71,9 @@ impl Compressor<bool> for PackedBoolCompressor {
     }
 }
 
-struct RLEBoolCompressor;
+struct RleBoolCompressor;
 
-impl Compressor<bool> for RLEBoolCompressor {
+impl Compressor<bool> for RleBoolCompressor {
     // TODO: fast_size_for
     fn compress<O: EncodeOptions>(&self, data: &[bool], stream: &mut EncoderStream<'_, O>) -> Result<ArrayTypeId, ()> {
         within_rle(|| encode_rle_bool(data, stream))
@@ -94,7 +94,7 @@ impl InfallibleDecoderArray for IntoIter<bool> {
             DynArrayBranch::Boolean(encoding) => {
                 let v = match encoding {
                     ArrayBool::Packed(bytes) => decode_packed_bool(&bytes).into_iter(),
-                    ArrayBool::RLE(first, runs) => {
+                    ArrayBool::Rle(first, runs) => {
                         let runs = <u64 as Decodable>::DecoderArray::new(*runs, options)?;
                         decode_rle_bool(runs, first)
                     }

--- a/tree-buf/src/lib.rs
+++ b/tree-buf/src/lib.rs
@@ -1,3 +1,20 @@
+#![deny(clippy::all)]
+#![warn(clippy::pedantic)]
+//
+// "This lint is meant to be deactivated by everyone doing serious performance work.
+//  This means having done the measurement."
+// (https://rust-lang.github.io/rust-clippy/master/index.html#inline_always)
+#![allow(clippy::inline_always)]
+//
+// Temp:
+#![allow(clippy::too_many_lines)]
+#![allow(clippy::result_unit_err)]
+#![allow(clippy::cast_possible_wrap)]
+#![allow(clippy::cast_possible_truncation)]
+#![allow(clippy::missing_errors_doc)]
+#![allow(clippy::missing_panics_doc)]
+#![allow(clippy::module_name_repetitions)]
+
 #[doc(hidden)]
 pub mod internal;
 


### PR DESCRIPTION
This is my attempt at adding
```
#![deny(clippy::all)]
#![warn(clippy::pedantic)]
```

I have appeased most of clippy's complaints but have `allow`ed the things that I think need deeper understanding of the codebase / more discussion / larger scale restructuring. 
